### PR TITLE
Add a "HTML" link style; Click icon to copy

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,7 +23,7 @@
   "raw": {
     "message": "Copy the raw URL."
   },
-  "html": {
-    "message": "Copy HTML plus a link."
+  "rich_plus_raw": {
+    "message": "Copy as rich text plus the raw URL."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -25,5 +25,20 @@
   },
   "rich_plus_raw": {
     "message": "Copy as rich text plus the raw URL."
+  },
+  "link_text": {
+    "message": "For the 'rich plus raw' style, select or set the word for the link:"
+  },
+  "link_text_option_1": {
+    "message": "[Source]"
+  },
+  "link_text_option_2": {
+    "message": "[Link]"
+  },
+  "link_text_option_3": {
+    "message": "🔗"
+  },
+  "link_text_option_4": {
+    "message": "Custom:"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -22,5 +22,8 @@
   },
   "raw": {
     "message": "Copy the raw URL."
+  },
+  "html": {
+    "message": "Copy HTML plus a link."
   }
 }

--- a/background_script.js
+++ b/background_script.js
@@ -158,7 +158,6 @@
   };
 
   const onCopy = async (info, tab) => {
-    console.log("on Copy: clicked");
     if (!SUPPORTS_TEXT_FRAGMENTS) {
       await polyfillTextFragments();
     }

--- a/background_script.js
+++ b/background_script.js
@@ -33,19 +33,19 @@
       return await sendMessageToPage('ping');
     } catch (err) {
       await Promise.all(
-          contentScriptNames.map((contentScriptName) => {
-            return new Promise((resolve) => {
-              browser.tabs.executeScript(
-                  {
-                    file: contentScriptName,
-                  },
-                  () => {
-                    log('Injected content script', contentScriptName);
-                    return resolve();
-                  },
-              );
-            });
-          }),
+        contentScriptNames.map((contentScriptName) => {
+          return new Promise((resolve) => {
+            browser.tabs.executeScript(
+              {
+                file: contentScriptName,
+              },
+              () => {
+                log('Injected content script', contentScriptName);
+                return resolve();
+              }
+            );
+          });
+        })
       );
     }
   };
@@ -53,15 +53,15 @@
   const askForAllOriginsPermission = async () => {
     return new Promise((resolve, reject) => {
       browser.permissions.request(
-          {
-            origins: ['http://*/*', 'https://*/*'],
-          },
-          (granted) => {
-            if (granted) {
-              return resolve();
-            }
-            return reject(new Error('Host permission not granted.'));
-          },
+        {
+          origins: ['http://*/*', 'https://*/*'],
+        },
+        (granted) => {
+          if (granted) {
+            return resolve();
+          }
+          return reject(new Error('Host permission not granted.'));
+        }
       );
     });
   };
@@ -81,19 +81,19 @@
   };
 
   browser.contextMenus.create(
-      {
-        title: browser.i18n.getMessage('copy_link'),
-        id: 'copy-link',
-        contexts: ['selection'],
-      },
-      () => {
-        if (browser.runtime.lastError) {
-          console.log(
-              'Error creating context menu item:',
-              browser.runtime.lastError,
-          );
-        }
-      },
+    {
+      title: browser.i18n.getMessage('copy_link'),
+      id: 'copy-link',
+      contexts: ['selection'],
+    },
+    () => {
+      if (browser.runtime.lastError) {
+        console.log(
+          'Error creating context menu item:',
+          browser.runtime.lastError
+        );
+      }
+    }
   );
 
   browser.commands.onCommand.addListener(async (command) => {
@@ -107,13 +107,13 @@
         'content_script.js',
       ]);
       browser.tabs.query(
-          {
-            active: true,
-            currentWindow: true,
-          },
-          (tabs) => {
-            startProcessing(tabs[0]);
-          },
+        {
+          active: true,
+          currentWindow: true,
+        },
+        (tabs) => {
+          startProcessing(tabs[0]);
+        }
       );
     }
   });
@@ -132,27 +132,27 @@
   const sendMessageToPage = (message, data = null) => {
     return new Promise((resolve, reject) => {
       browser.tabs.query(
-          {
-            active: true,
-            currentWindow: true,
-          },
-          (tabs) => {
-            browser.tabs.sendMessage(
-                tabs[0].id,
-                {
-                  message,
-                  data,
-                },
-                (response) => {
-                  if (!response) {
-                    return reject(
-                        new Error('Failed to connect to the specified tab.'),
-                    );
-                  }
-                  return resolve(response);
-                },
-            );
-          },
+        {
+          active: true,
+          currentWindow: true,
+        },
+        (tabs) => {
+          browser.tabs.sendMessage(
+            tabs[0].id,
+            {
+              message,
+              data,
+            },
+            (response) => {
+              if (!response) {
+                return reject(
+                  new Error('Failed to connect to the specified tab.')
+                );
+              }
+              return resolve(response);
+            }
+          );
+        }
       );
     });
   };

--- a/background_script.js
+++ b/background_script.js
@@ -118,17 +118,7 @@
     }
   });
 
-  browser.contextMenus.onClicked.addListener(async (info, tab) => {
-    if (!SUPPORTS_TEXT_FRAGMENTS) {
-      await polyfillTextFragments();
-    }
-    await injectContentScripts([
-      'prepare.js',
-      'fragment-generation-utils.js',
-      'content_script.js',
-    ]);
-    startProcessing(tab);
-  });
+  browser.contextMenus.onClicked.addListener((info, tab) => onCopy(info, tab));
 
   const startProcessing = async (tab) => {
     try {
@@ -167,8 +157,8 @@
     });
   };
 
-  chrome.browserAction.onClicked.addListener(async (info, tab) => {
-    console.log("Clicked");
+  const onCopy = async (info, tab) => {
+    console.log("on Copy: clicked");
     if (!SUPPORTS_TEXT_FRAGMENTS) {
       await polyfillTextFragments();
     }
@@ -178,6 +168,8 @@
       'content_script.js',
     ]);
     startProcessing(tab);
-  });
+  };
+
+  chrome.browserAction.onClicked.addListener((info, tab) => onCopy(info, tab));
   // eslint-disable-next-line no-undef
 })(chrome || browser);

--- a/background_script.js
+++ b/background_script.js
@@ -166,5 +166,18 @@
       );
     });
   };
+
+  chrome.browserAction.onClicked.addListener(async (info, tab) => {
+    console.log("Clicked");
+    if (!SUPPORTS_TEXT_FRAGMENTS) {
+      await polyfillTextFragments();
+    }
+    await injectContentScripts([
+      'prepare.js',
+      'fragment-generation-utils.js',
+      'content_script.js',
+    ]);
+    startProcessing(tab);
+  });
   // eslint-disable-next-line no-undef
 })(chrome || browser);

--- a/content_script.js
+++ b/content_script.js
@@ -112,7 +112,7 @@
           );
           */
         }
-        else if (linkStyle === 'html') {
+        else if (linkStyle === 'rich_plus_raw') {
           var html = "";
           if (selection.rangeCount) {
               var container = document.createElement("div");

--- a/content_script.js
+++ b/content_script.js
@@ -113,7 +113,7 @@
           */
         }
         else if (linkStyle === 'rich_plus_raw') {
-          var html = "";
+          let html = '';
           if (selection.rangeCount) {
               var container = document.createElement("div");
               for (var i = 0, len = selection.rangeCount; i < len; ++i) {

--- a/content_script.js
+++ b/content_script.js
@@ -94,7 +94,7 @@
         };
         if (linkStyle === 'rich') {
           clipboardItems['text/html'] = new Blob(
-              [`<a href="${url}">${selection.toString()}</a>`],
+              [`<a href="${encodeURI(url)}">${selection.toString()}</a>`],
               {
                 type: 'text/html',
               },
@@ -122,7 +122,7 @@
               html = container.innerHTML;
           }
           clipboardItems['text/html'] = new Blob(
-              [`${html} [🔗](${url})`],
+              [`${html} <a href="${encodeURI(url)}">🔗</a>`],
               {type: 'text/html'},
           );
         }

--- a/content_script.js
+++ b/content_script.js
@@ -116,7 +116,7 @@
           let html = '';
           if (selection.rangeCount) {
               const container = document.createElement('div');
-              for (var i = 0, len = selection.rangeCount; i < len; ++i) {
+              for (let i = 0, len = selection.rangeCount; i < len; ++i) {
                   container.appendChild(selection.getRangeAt(i).cloneContents());
               }
               html = container.innerHTML;

--- a/content_script.js
+++ b/content_script.js
@@ -40,7 +40,7 @@
         `,${encodeURIComponent(fragment.textEnd)}` :
         '';
       url = `${url}#:~:text=${prefix}${textStart}${textEnd}${suffix}`;
-      copyToClipboard(url, selection.toString());
+      copyToClipboard(url, selection);
       reportSuccess();
       return url;
     } else {
@@ -78,7 +78,7 @@
     return true;
   };
 
-  const copyToClipboard = (url, selectedText) => {
+  const copyToClipboard = (url, selection) => {
     browser.storage.sync.get({linkStyle: 'rich'}, async (items) => {
       const linkStyle = items.linkStyle;
       // Try to use the Async Clipboard API with fallback to the legacy API.
@@ -94,7 +94,7 @@
         };
         if (linkStyle === 'rich') {
           clipboardItems['text/html'] = new Blob(
-              [`<a href="${url}">${selectedText}</a>`],
+              [`<a href="${url}">${selection.toString()}</a>`],
               {
                 type: 'text/html',
               },
@@ -104,7 +104,7 @@
           clipboardItems['text/rtf'] = new Blob(
             [
               `{\field{\*\fldinst HYPERLINK "${url}"}{\fldrslt ${
-                  selectedText}}}`,
+                  selection.toString()}}}`,
             ],
             {
               type: 'text/rtf',
@@ -112,6 +112,21 @@
           );
           */
         }
+        else if (linkStyle === 'html') {
+          var html = "";
+          if (selection.rangeCount) {
+              var container = document.createElement("div");
+              for (var i = 0, len = selection.rangeCount; i < len; ++i) {
+                  container.appendChild(selection.getRangeAt(i).cloneContents());
+              }
+              html = container.innerHTML;
+          }
+          clipboardItems['text/html'] = new Blob(
+              [`${html} [🔗](${url})`],
+              {type: 'text/html'},
+          );
+        }
+
         const clipboardData = [new ClipboardItem(clipboardItems)];
         /* global ClipboardItem */
         await navigator.clipboard.write(clipboardData);

--- a/content_script.js
+++ b/content_script.js
@@ -115,7 +115,7 @@
         else if (linkStyle === 'rich_plus_raw') {
           let html = '';
           if (selection.rangeCount) {
-              var container = document.createElement("div");
+              const container = document.createElement('div');
               for (var i = 0, len = selection.rangeCount; i < len; ++i) {
                   container.appendChild(selection.getRangeAt(i).cloneContents());
               }

--- a/content_script.js
+++ b/content_script.js
@@ -79,7 +79,9 @@
   };
 
   const copyToClipboard = (url, selection) => {
-    browser.storage.sync.get({linkStyle: 'rich'}, async (items) => {
+    browser.storage.sync.get(
+        {linkStyle: 'rich', linkText: browser.i18n.getMessage('link_text_option_1')},
+        async (items) => {
       const linkStyle = items.linkStyle;
       // Try to use the Async Clipboard API with fallback to the legacy API.
       try {
@@ -122,7 +124,7 @@
               html = container.innerHTML;
           }
           clipboardItems['text/html'] = new Blob(
-              [`${html} <a href="${encodeURI(url)}">🔗</a>`],
+              [`${html} <a href="${encodeURI(url)}">${items.linkText}</a>`],
               {type: 'text/html'},
           );
         }

--- a/content_script.js
+++ b/content_script.js
@@ -29,16 +29,16 @@
     let url = `${location.origin}${location.pathname}${location.search}`;
     if (result.status === 0) {
       const fragment = result.fragment;
-      const prefix = fragment.prefix ?
-        `${encodeURIComponent(fragment.prefix)}-,` :
-        '';
-      const suffix = fragment.suffix ?
-        `,-${encodeURIComponent(fragment.suffix)}` :
-        '';
+      const prefix = fragment.prefix
+        ? `${encodeURIComponent(fragment.prefix)}-,`
+        : '';
+      const suffix = fragment.suffix
+        ? `,-${encodeURIComponent(fragment.suffix)}`
+        : '';
       const textStart = encodeURIComponent(fragment.textStart);
-      const textEnd = fragment.textEnd ?
-        `,${encodeURIComponent(fragment.textEnd)}` :
-        '';
+      const textEnd = fragment.textEnd
+        ? `,${encodeURIComponent(fragment.textEnd)}`
+        : '';
       url = `${url}#:~:text=${prefix}${textStart}${textEnd}${suffix}`;
       copyToClipboard(url, selection);
       reportSuccess();
@@ -70,9 +70,9 @@
   const reportFailure = () => {
     window.queueMicrotask(() => {
       alert(
-          `🛑 ${browser.i18n.getMessage(
-              'extension_name',
-          )}:\n${browser.i18n.getMessage('link_failure')}`,
+        `🛑 ${browser.i18n.getMessage(
+          'extension_name'
+        )}:\n${browser.i18n.getMessage('link_failure')}`
       );
     });
     return true;
@@ -80,29 +80,32 @@
 
   const copyToClipboard = (url, selection) => {
     browser.storage.sync.get(
-        {linkStyle: 'rich', linkText: browser.i18n.getMessage('link_text_option_1')},
-        async (items) => {
-      const linkStyle = items.linkStyle;
-      // Try to use the Async Clipboard API with fallback to the legacy API.
-      try {
-        const {state} = await navigator.permissions.query({
-          name: 'clipboard-write',
-        });
-        if (state !== 'granted') {
-          throw new Error('Clipboard permission not granted');
-        }
-        const clipboardItems = {
-          'text/plain': new Blob([url], {type: 'text/plain'}),
-        };
-        if (linkStyle === 'rich') {
-          clipboardItems['text/html'] = new Blob(
+      {
+        linkStyle: 'rich',
+        linkText: browser.i18n.getMessage('link_text_option_1'),
+      },
+      async (items) => {
+        const linkStyle = items.linkStyle;
+        // Try to use the Async Clipboard API with fallback to the legacy API.
+        try {
+          const { state } = await navigator.permissions.query({
+            name: 'clipboard-write',
+          });
+          if (state !== 'granted') {
+            throw new Error('Clipboard permission not granted');
+          }
+          const clipboardItems = {
+            'text/plain': new Blob([url], { type: 'text/plain' }),
+          };
+          if (linkStyle === 'rich') {
+            clipboardItems['text/html'] = new Blob(
               [`<a href="${encodeURI(url)}">${selection.toString()}</a>`],
               {
                 type: 'text/html',
-              },
-          );
-          // ToDo: Activate once supported.
-          /*
+              }
+            );
+            // ToDo: Activate once supported.
+            /*
           clipboardItems['text/rtf'] = new Blob(
             [
               `{\field{\*\fldinst HYPERLINK "${url}"}{\fldrslt ${
@@ -113,36 +116,36 @@
             }
           );
           */
-        }
-        else if (linkStyle === 'rich_plus_raw') {
-          let html = '';
-          if (selection.rangeCount) {
+          } else if (linkStyle === 'rich_plus_raw') {
+            let html = '';
+            if (selection.rangeCount) {
               const container = document.createElement('div');
               for (let i = 0, len = selection.rangeCount; i < len; ++i) {
-                  container.appendChild(selection.getRangeAt(i).cloneContents());
+                container.appendChild(selection.getRangeAt(i).cloneContents());
               }
               html = container.innerHTML;
-          }
-          clipboardItems['text/html'] = new Blob(
+            }
+            clipboardItems['text/html'] = new Blob(
               [`${html} <a href="${encodeURI(url)}">${items.linkText}</a>`],
-              {type: 'text/html'},
-          );
-        }
+              { type: 'text/html' }
+            );
+          }
 
-        const clipboardData = [new ClipboardItem(clipboardItems)];
-        /* global ClipboardItem */
-        await navigator.clipboard.write(clipboardData);
-      } catch (err) {
-        const textArea = document.createElement('textarea');
-        document.body.append(textArea);
-        textArea.textContent = url;
-        textArea.select();
-        document.execCommand('copy');
-        textArea.remove();
+          const clipboardData = [new ClipboardItem(clipboardItems)];
+          /* global ClipboardItem */
+          await navigator.clipboard.write(clipboardData);
+        } catch (err) {
+          const textArea = document.createElement('textarea');
+          document.body.append(textArea);
+          textArea.textContent = url;
+          textArea.select();
+          document.execCommand('copy');
+          textArea.remove();
+        }
+        log('🎉', url);
+        return true;
       }
-      log('🎉', url);
-      return true;
-    });
+    );
   };
 
   browser.runtime.onMessage.addListener((request, _, sendResponse) => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extension_name__",
   "short_name": "__MSG_extension_short_name__",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "__MSG_extension_description__",
   "background": {
     "scripts": [
@@ -17,6 +17,7 @@
   },
   "permissions": ["activeTab", "contextMenus", "clipboardWrite", "storage"],
   "optional_permissions": ["http://*/*", "https://*/*"],
+  "browser_action": {},
   "manifest_version": 2,
   "icons": {
     "16": "assets/16x16.png",

--- a/options.html
+++ b/options.html
@@ -20,27 +20,47 @@
     <h1></h1>
     <form>
       <p>
-        <label><input type="radio" id="rich" name="style" /> <span class="rich"></span></label>
+        <label
+          ><input type="radio" id="rich" name="style" />
+          <span class="rich"></span
+        ></label>
       </p>
       <p>
-        <label><input type="radio" id="raw" name="style" /> <span class="raw"></span></label>
+        <label
+          ><input type="radio" id="raw" name="style" /> <span class="raw"></span
+        ></label>
       </p>
       <p>
-        <label><input type="radio" id="rich-plus-raw" name="style" /> <span class="rich-plus-raw"></span></label>
+        <label
+          ><input type="radio" id="rich-plus-raw" name="style" />
+          <span class="rich-plus-raw"></span
+        ></label>
       </p>
 
       <h4></h4>
       <p>
-        <label><input type="radio" id="link-text-option-1" name="link-text" /> <span class="link-text-option-1"></span></label>
+        <label
+          ><input type="radio" id="link-text-option-1" name="link-text" />
+          <span class="link-text-option-1"></span
+        ></label>
       </p>
       <p>
-        <label><input type="radio" id="link-text-option-2" name="link-text" /> <span class="link-text-option-2"></span></label>
+        <label
+          ><input type="radio" id="link-text-option-2" name="link-text" />
+          <span class="link-text-option-2"></span
+        ></label>
       </p>
       <p>
-        <label><input type="radio" id="link-text-option-3" name="link-text" /> <span class="link-text-option-3"></span></label>
+        <label
+          ><input type="radio" id="link-text-option-3" name="link-text" />
+          <span class="link-text-option-3"></span
+        ></label>
       </p>
       <p>
-        <label><input type="radio" id="link-text-option-4" name="link-text" /> <span class="link-text-option-4"></span></label>
+        <label
+          ><input type="radio" id="link-text-option-4" name="link-text" />
+          <span class="link-text-option-4"></span
+        ></label>
         <input type="text" id="link-text-input" name="link-text" />
       </p>
     </form>

--- a/options.html
+++ b/options.html
@@ -32,7 +32,7 @@
       </p>
       <p>
         <label
-          ><input type="radio" id="html" name="style" /> <span class="html"></span
+          ><input type="radio" id="rich_plus_raw" name="style" /> <span class="rich_plus_raw"></span
         ></label>
       </p>
     </form>

--- a/options.html
+++ b/options.html
@@ -30,6 +30,11 @@
           ><input type="radio" id="raw" name="style" /> <span class="raw"></span
         ></label>
       </p>
+      <p>
+        <label
+          ><input type="radio" id="html" name="style" /> <span class="html"></span
+        ></label>
+      </p>
     </form>
     <script src="options.js"></script>
   </body>

--- a/options.html
+++ b/options.html
@@ -20,20 +20,28 @@
     <h1></h1>
     <form>
       <p>
-        <label
-          ><input type="radio" id="rich" name="style" />
-          <span class="rich"></span
-        ></label>
+        <label><input type="radio" id="rich" name="style" /> <span class="rich"></span></label>
       </p>
       <p>
-        <label
-          ><input type="radio" id="raw" name="style" /> <span class="raw"></span
-        ></label>
+        <label><input type="radio" id="raw" name="style" /> <span class="raw"></span></label>
       </p>
       <p>
-        <label
-          ><input type="radio" id="rich_plus_raw" name="style" /> <span class="rich_plus_raw"></span
-        ></label>
+        <label><input type="radio" id="rich_plus_raw" name="style" /> <span class="rich_plus_raw"></span></label>
+      </p>
+
+      <h4></h4>
+      <p>
+        <label><input type="radio" id="link_text_option_1" name="link_text" /> <span class="link_text_option_1"></span></label>
+      </p>
+      <p>
+        <label><input type="radio" id="link_text_option_2" name="link_text" /> <span class="link_text_option_2"></span></label>
+      </p>
+      <p>
+        <label><input type="radio" id="link_text_option_3" name="link_text" /> <span class="link_text_option_3"></span></label>
+      </p>
+      <p>
+        <label><input type="radio" id="link_text_option_4" name="link_text" /> <span class="link_text_option_4"></span></label>
+        <input type="text" id="link_text_input" name="link_text" />
       </p>
     </form>
     <script src="options.js"></script>

--- a/options.html
+++ b/options.html
@@ -26,22 +26,22 @@
         <label><input type="radio" id="raw" name="style" /> <span class="raw"></span></label>
       </p>
       <p>
-        <label><input type="radio" id="rich_plus_raw" name="style" /> <span class="rich_plus_raw"></span></label>
+        <label><input type="radio" id="rich-plus-raw" name="style" /> <span class="rich-plus-raw"></span></label>
       </p>
 
       <h4></h4>
       <p>
-        <label><input type="radio" id="link_text_option_1" name="link_text" /> <span class="link_text_option_1"></span></label>
+        <label><input type="radio" id="link-text-option-1" name="link-text" /> <span class="link-text-option-1"></span></label>
       </p>
       <p>
-        <label><input type="radio" id="link_text_option_2" name="link_text" /> <span class="link_text_option_2"></span></label>
+        <label><input type="radio" id="link-text-option-2" name="link-text" /> <span class="link-text-option-2"></span></label>
       </p>
       <p>
-        <label><input type="radio" id="link_text_option_3" name="link_text" /> <span class="link_text_option_3"></span></label>
+        <label><input type="radio" id="link-text-option-3" name="link-text" /> <span class="link-text-option-3"></span></label>
       </p>
       <p>
-        <label><input type="radio" id="link_text_option_4" name="link_text" /> <span class="link_text_option_4"></span></label>
-        <input type="text" id="link_text_input" name="link_text" />
+        <label><input type="radio" id="link-text-option-4" name="link-text" /> <span class="link-text-option-4"></span></label>
+        <input type="text" id="link-text-input" name="link-text" />
       </p>
     </form>
     <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,36 +1,97 @@
 ((browser) => {
-  document.querySelector('h1').textContent =
-    browser.i18n.getMessage('link_copy_style');
+  document.querySelector('h1').textContent = browser.i18n.getMessage('link_copy_style');
   document.querySelector('.rich').textContent = browser.i18n.getMessage('rich');
   document.querySelector('.raw').textContent = browser.i18n.getMessage('raw');
   document.querySelector('.rich_plus_raw').textContent = browser.i18n.getMessage('rich_plus_raw');
+  document.querySelector('h4').textContent = browser.i18n.getMessage('link_text');
+  document.querySelector('.link_text_option_1').textContent = browser.i18n.getMessage('link_text_option_1');
+  document.querySelector('.link_text_option_2').textContent = browser.i18n.getMessage('link_text_option_2');
+  document.querySelector('.link_text_option_3').textContent = browser.i18n.getMessage('link_text_option_3');
+  document.querySelector('.link_text_option_4').textContent = browser.i18n.getMessage('link_text_option_4');
 
   const rich = document.querySelector('#rich');
   const raw = document.querySelector('#raw');
   const rich_plus_raw = document.querySelector('#rich_plus_raw');
 
+  const link_text_option_1 = document.querySelector('#link_text_option_1');
+  const link_text_option_2 = document.querySelector('#link_text_option_2');
+  const link_text_option_3 = document.querySelector('#link_text_option_3');
+  const link_text_option_4 = document.querySelector('#link_text_option_4');
+  const link_text_input = document.querySelector('#link_text_input');
+
+  const enableLinkTextOptions = (enabled) => {
+    document.getElementsByName("link_text").forEach((e) => {
+      e.disabled = !enabled;
+    });
+  };
+
   // Restore previous settings.
-  browser.storage.sync.get({linkStyle: 'rich'}, (items) => {
+  browser.storage.sync.get({linkStyle: 'rich', linkText: document.querySelector('.link_text_option_1').textContent}, (items) => {
     rich.checked = items.linkStyle === 'rich';
     raw.checked = items.linkStyle === 'raw';
     rich_plus_raw.checked = items.linkStyle === 'rich_plus_raw';
+
+    link_text_option_1.checked = items.linkText === document.querySelector('.link_text_option_1').textContent;
+    link_text_option_2.checked = items.linkText === document.querySelector('.link_text_option_2').textContent;
+    link_text_option_3.checked = items.linkText === document.querySelector('.link_text_option_3').textContent;
+    if (!link_text_option_1.checked && !link_text_option_2.checked && !link_text_option_3.checked) {
+        link_text_option_4.checked = true;
+        link_text_input.value = items.linkText;
+    }
+
+    enableLinkTextOptions(rich_plus_raw.checked);
   });
 
   // Save settings on change.
-  rich.addEventListener('change', () => {
+  rich.addEventListener('click', () => {
+    browser.storage.sync.set({linkStyle: 'rich'});
+    enableLinkTextOptions(rich_plus_raw.checked);
+  });
+  raw.addEventListener('click', () => {
+    browser.storage.sync.set({linkStyle: 'raw'});
+    enableLinkTextOptions(rich_plus_raw.checked);
+  });
+  rich_plus_raw.addEventListener('click', () => {
+    browser.storage.sync.set({linkStyle: 'rich_plus_raw'});
+    enableLinkTextOptions(rich_plus_raw.checked);
+  });
+
+  link_text_option_1.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
+      linkText: document.querySelector('.link_text_option_1').textContent,
     });
   });
-  raw.addEventListener('change', () => {
+  link_text_option_2.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
+      linkText: document.querySelector('.link_text_option_2').textContent,
     });
   });
-  rich_plus_raw.addEventListener('change', () => {
+  link_text_option_3.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
+      linkText: document.querySelector('.link_text_option_3').textContent,
     });
   });
+  link_text_option_4.addEventListener('click', () => {
+    link_text_input.focus();
+    browser.storage.sync.set({
+      linkText: link_text_input.value,
+    });
+  });
+  link_text_input.addEventListener('focus', () => {
+    link_text_option_4.checked = true;
+  });
+  link_text_input.addEventListener('change', () => {
+    if (link_text_input.value.replace(/\s/g, '').length > 0) {
+      browser.storage.sync.set({
+          linkText: link_text_input.value,
+      });
+    }
+    else {
+      browser.storage.sync.set({
+        linkText: document.querySelector('.link_text_option_1').textContent,
+      });
+    }
+  });
+
   // eslint-disable-next-line no-undef
 })(chrome || browser);

--- a/options.js
+++ b/options.js
@@ -3,33 +3,33 @@
     browser.i18n.getMessage('link_copy_style');
   document.querySelector('.rich').textContent = browser.i18n.getMessage('rich');
   document.querySelector('.raw').textContent = browser.i18n.getMessage('raw');
-  document.querySelector('.html').textContent = browser.i18n.getMessage('html');
+  document.querySelector('.rich_plus_raw').textContent = browser.i18n.getMessage('rich_plus_raw');
 
   const rich = document.querySelector('#rich');
   const raw = document.querySelector('#raw');
-  const html = document.querySelector('#html');
+  const rich_plus_raw = document.querySelector('#rich_plus_raw');
 
   // Restore previous settings.
   browser.storage.sync.get({linkStyle: 'rich'}, (items) => {
     rich.checked = items.linkStyle === 'rich';
     raw.checked = items.linkStyle === 'raw';
-    html.checked = items.linkStyle === 'html';
+    rich_plus_raw.checked = items.linkStyle === 'rich_plus_raw';
   });
 
   // Save settings on change.
   rich.addEventListener('change', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
     });
   });
   raw.addEventListener('change', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
     });
   });
-  html.addEventListener('change', () => {
+  rich_plus_raw.addEventListener('change', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'rich_plus_raw'),
     });
   });
   // eslint-disable-next-line no-undef

--- a/options.js
+++ b/options.js
@@ -3,24 +3,34 @@
     browser.i18n.getMessage('link_copy_style');
   document.querySelector('.rich').textContent = browser.i18n.getMessage('rich');
   document.querySelector('.raw').textContent = browser.i18n.getMessage('raw');
+  document.querySelector('.html').textContent = browser.i18n.getMessage('html');
 
   const rich = document.querySelector('#rich');
   const raw = document.querySelector('#raw');
+  const html = document.querySelector('#html');
 
   // Restore previous settings.
   browser.storage.sync.get({linkStyle: 'rich'}, (items) => {
     rich.checked = items.linkStyle === 'rich';
     raw.checked = items.linkStyle === 'raw';
+    html.checked = items.linkStyle === 'html';
   });
 
   // Save settings on change.
   rich.addEventListener('change', () => {
     browser.storage.sync.set({
-      linkStyle: rich.checked ? 'rich' : 'raw',
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
     });
   });
   raw.addEventListener('change', () => {
-    browser.storage.sync.set({linkStyle: raw.checked ? 'raw' : 'rich'});
+    browser.storage.sync.set({
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
+    });
+  });
+  html.addEventListener('change', () => {
+    browser.storage.sync.set({
+      linkStyle: rich.checked ? 'rich' : (raw.checked ? 'raw' : 'html'),
+    });
   });
   // eslint-disable-next-line no-undef
 })(chrome || browser);

--- a/options.js
+++ b/options.js
@@ -1,13 +1,20 @@
 ((browser) => {
-  document.querySelector('h1').textContent = browser.i18n.getMessage('link_copy_style');
+  document.querySelector('h1').textContent =
+    browser.i18n.getMessage('link_copy_style');
   document.querySelector('.rich').textContent = browser.i18n.getMessage('rich');
   document.querySelector('.raw').textContent = browser.i18n.getMessage('raw');
-  document.querySelector('.rich-plus-raw').textContent = browser.i18n.getMessage('rich_plus_raw');
-  document.querySelector('h4').textContent = browser.i18n.getMessage('link_text');
-  document.querySelector('.link-text-option-1').textContent = browser.i18n.getMessage('link_text_option_1');
-  document.querySelector('.link-text-option-2').textContent = browser.i18n.getMessage('link_text_option_2');
-  document.querySelector('.link-text-option-3').textContent = browser.i18n.getMessage('link_text_option_3');
-  document.querySelector('.link-text-option-4').textContent = browser.i18n.getMessage('link_text_option_4');
+  document.querySelector('.rich-plus-raw').textContent =
+    browser.i18n.getMessage('rich_plus_raw');
+  document.querySelector('h4').textContent =
+    browser.i18n.getMessage('link_text');
+  document.querySelector('.link-text-option-1').textContent =
+    browser.i18n.getMessage('link_text_option_1');
+  document.querySelector('.link-text-option-2').textContent =
+    browser.i18n.getMessage('link_text_option_2');
+  document.querySelector('.link-text-option-3').textContent =
+    browser.i18n.getMessage('link_text_option_3');
+  document.querySelector('.link-text-option-4').textContent =
+    browser.i18n.getMessage('link_text_option_4');
 
   const rich = document.querySelector('#rich');
   const raw = document.querySelector('#raw');
@@ -20,37 +27,53 @@
   const linkTextInput = document.querySelector('#link-text-input');
 
   const enableLinkTextOptions = (enabled) => {
-    document.getElementsByName("link-text").forEach((e) => {
+    document.getElementsByName('link-text').forEach((e) => {
       e.disabled = !enabled;
     });
   };
 
   // Restore previous settings.
-  browser.storage.sync.get({linkStyle: 'rich', linkText: document.querySelector('.link-text-option-1').textContent}, (items) => {
-    rich.checked = items.linkStyle === 'rich';
-    raw.checked = items.linkStyle === 'raw';
-    richPlusRaw.checked = items.linkStyle === 'rich_plus_raw';
-    linkTextOption1.checked = items.linkText === document.querySelector('.link-text-option-1').textContent;
-    linkTextOption2.checked = items.linkText === document.querySelector('.link-text-option-2').textContent;
-    linkTextOption3.checked = items.linkText === document.querySelector('.link-text-option-3').textContent;
-    if (!linkTextOption1.checked && !linkTextOption2.checked && !linkTextOption3.checked) {
+  browser.storage.sync.get(
+    {
+      linkStyle: 'rich',
+      linkText: document.querySelector('.link-text-option-1').textContent,
+    },
+    (items) => {
+      rich.checked = items.linkStyle === 'rich';
+      raw.checked = items.linkStyle === 'raw';
+      richPlusRaw.checked = items.linkStyle === 'rich_plus_raw';
+      linkTextOption1.checked =
+        items.linkText ===
+        document.querySelector('.link-text-option-1').textContent;
+      linkTextOption2.checked =
+        items.linkText ===
+        document.querySelector('.link-text-option-2').textContent;
+      linkTextOption3.checked =
+        items.linkText ===
+        document.querySelector('.link-text-option-3').textContent;
+      if (
+        !linkTextOption1.checked &&
+        !linkTextOption2.checked &&
+        !linkTextOption3.checked
+      ) {
         linkTextOption4.checked = true;
         linkTextInput.value = items.linkText;
+      }
+      enableLinkTextOptions(richPlusRaw.checked);
     }
-    enableLinkTextOptions(richPlusRaw.checked);
-  });
+  );
 
   // Save settings on change.
   rich.addEventListener('click', () => {
-    browser.storage.sync.set({linkStyle: 'rich'});
+    browser.storage.sync.set({ linkStyle: 'rich' });
     enableLinkTextOptions(richPlusRaw.checked);
   });
   raw.addEventListener('click', () => {
-    browser.storage.sync.set({linkStyle: 'raw'});
+    browser.storage.sync.set({ linkStyle: 'raw' });
     enableLinkTextOptions(richPlusRaw.checked);
   });
   richPlusRaw.addEventListener('click', () => {
-    browser.storage.sync.set({linkStyle: 'rich_plus_raw'});
+    browser.storage.sync.set({ linkStyle: 'rich_plus_raw' });
     enableLinkTextOptions(richPlusRaw.checked);
   });
 
@@ -81,10 +104,9 @@
   linkTextInput.addEventListener('change', () => {
     if (linkTextInput.value.replace(/\s/g, '').length > 0) {
       browser.storage.sync.set({
-          linkText: linkTextInput.value,
+        linkText: linkTextInput.value,
       });
-    }
-    else {
+    } else {
       browser.storage.sync.set({
         linkText: document.querySelector('.link-text-option-1').textContent,
       });

--- a/options.js
+++ b/options.js
@@ -2,93 +2,91 @@
   document.querySelector('h1').textContent = browser.i18n.getMessage('link_copy_style');
   document.querySelector('.rich').textContent = browser.i18n.getMessage('rich');
   document.querySelector('.raw').textContent = browser.i18n.getMessage('raw');
-  document.querySelector('.rich_plus_raw').textContent = browser.i18n.getMessage('rich_plus_raw');
+  document.querySelector('.rich-plus-raw').textContent = browser.i18n.getMessage('rich_plus_raw');
   document.querySelector('h4').textContent = browser.i18n.getMessage('link_text');
-  document.querySelector('.link_text_option_1').textContent = browser.i18n.getMessage('link_text_option_1');
-  document.querySelector('.link_text_option_2').textContent = browser.i18n.getMessage('link_text_option_2');
-  document.querySelector('.link_text_option_3').textContent = browser.i18n.getMessage('link_text_option_3');
-  document.querySelector('.link_text_option_4').textContent = browser.i18n.getMessage('link_text_option_4');
+  document.querySelector('.link-text-option-1').textContent = browser.i18n.getMessage('link_text_option_1');
+  document.querySelector('.link-text-option-2').textContent = browser.i18n.getMessage('link_text_option_2');
+  document.querySelector('.link-text-option-3').textContent = browser.i18n.getMessage('link_text_option_3');
+  document.querySelector('.link-text-option-4').textContent = browser.i18n.getMessage('link_text_option_4');
 
   const rich = document.querySelector('#rich');
   const raw = document.querySelector('#raw');
-  const rich_plus_raw = document.querySelector('#rich_plus_raw');
+  const richPlusRaw = document.querySelector('#rich-plus-raw');
 
-  const link_text_option_1 = document.querySelector('#link_text_option_1');
-  const link_text_option_2 = document.querySelector('#link_text_option_2');
-  const link_text_option_3 = document.querySelector('#link_text_option_3');
-  const link_text_option_4 = document.querySelector('#link_text_option_4');
-  const link_text_input = document.querySelector('#link_text_input');
+  const linkTextOption1 = document.querySelector('#link-text-option-1');
+  const linkTextOption2 = document.querySelector('#link-text-option-2');
+  const linkTextOption3 = document.querySelector('#link-text-option-3');
+  const linkTextOption4 = document.querySelector('#link-text-option-4');
+  const linkTextInput = document.querySelector('#link-text-input');
 
   const enableLinkTextOptions = (enabled) => {
-    document.getElementsByName("link_text").forEach((e) => {
+    document.getElementsByName("link-text").forEach((e) => {
       e.disabled = !enabled;
     });
   };
 
   // Restore previous settings.
-  browser.storage.sync.get({linkStyle: 'rich', linkText: document.querySelector('.link_text_option_1').textContent}, (items) => {
+  browser.storage.sync.get({linkStyle: 'rich', linkText: document.querySelector('.link-text-option-1').textContent}, (items) => {
     rich.checked = items.linkStyle === 'rich';
     raw.checked = items.linkStyle === 'raw';
-    rich_plus_raw.checked = items.linkStyle === 'rich_plus_raw';
-
-    link_text_option_1.checked = items.linkText === document.querySelector('.link_text_option_1').textContent;
-    link_text_option_2.checked = items.linkText === document.querySelector('.link_text_option_2').textContent;
-    link_text_option_3.checked = items.linkText === document.querySelector('.link_text_option_3').textContent;
-    if (!link_text_option_1.checked && !link_text_option_2.checked && !link_text_option_3.checked) {
-        link_text_option_4.checked = true;
-        link_text_input.value = items.linkText;
+    richPlusRaw.checked = items.linkStyle === 'rich_plus_raw';
+    linkTextOption1.checked = items.linkText === document.querySelector('.link-text-option-1').textContent;
+    linkTextOption2.checked = items.linkText === document.querySelector('.link-text-option-2').textContent;
+    linkTextOption3.checked = items.linkText === document.querySelector('.link-text-option-3').textContent;
+    if (!linkTextOption1.checked && !linkTextOption2.checked && !linkTextOption3.checked) {
+        linkTextOption4.checked = true;
+        linkTextInput.value = items.linkText;
     }
-
-    enableLinkTextOptions(rich_plus_raw.checked);
+    enableLinkTextOptions(richPlusRaw.checked);
   });
 
   // Save settings on change.
   rich.addEventListener('click', () => {
     browser.storage.sync.set({linkStyle: 'rich'});
-    enableLinkTextOptions(rich_plus_raw.checked);
+    enableLinkTextOptions(richPlusRaw.checked);
   });
   raw.addEventListener('click', () => {
     browser.storage.sync.set({linkStyle: 'raw'});
-    enableLinkTextOptions(rich_plus_raw.checked);
+    enableLinkTextOptions(richPlusRaw.checked);
   });
-  rich_plus_raw.addEventListener('click', () => {
+  richPlusRaw.addEventListener('click', () => {
     browser.storage.sync.set({linkStyle: 'rich_plus_raw'});
-    enableLinkTextOptions(rich_plus_raw.checked);
+    enableLinkTextOptions(richPlusRaw.checked);
   });
 
-  link_text_option_1.addEventListener('click', () => {
+  linkTextOption1.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkText: document.querySelector('.link_text_option_1').textContent,
+      linkText: document.querySelector('.link-text-option-1').textContent,
     });
   });
-  link_text_option_2.addEventListener('click', () => {
+  linkTextOption2.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkText: document.querySelector('.link_text_option_2').textContent,
+      linkText: document.querySelector('.link-text-option-2').textContent,
     });
   });
-  link_text_option_3.addEventListener('click', () => {
+  linkTextOption3.addEventListener('click', () => {
     browser.storage.sync.set({
-      linkText: document.querySelector('.link_text_option_3').textContent,
+      linkText: document.querySelector('.link-text-option-3').textContent,
     });
   });
-  link_text_option_4.addEventListener('click', () => {
-    link_text_input.focus();
+  linkTextOption4.addEventListener('click', () => {
+    linkTextInput.focus();
     browser.storage.sync.set({
-      linkText: link_text_input.value,
+      linkText: linkTextInput.value,
     });
   });
-  link_text_input.addEventListener('focus', () => {
-    link_text_option_4.checked = true;
+  linkTextInput.addEventListener('focus', () => {
+    linkTextOption4.checked = true;
   });
-  link_text_input.addEventListener('change', () => {
-    if (link_text_input.value.replace(/\s/g, '').length > 0) {
+  linkTextInput.addEventListener('change', () => {
+    if (linkTextInput.value.replace(/\s/g, '').length > 0) {
       browser.storage.sync.set({
-          linkText: link_text_input.value,
+          linkText: linkTextInput.value,
       });
     }
     else {
       browser.storage.sync.set({
-        linkText: document.querySelector('.link_text_option_1').textContent,
+        linkText: document.querySelector('.link-text-option-1').textContent,
       });
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "link-to-text-fragment",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Browser extension that allows for linking to arbitrary text fragments.",
   "scripts": {
     "fix": "npx prettier --write .",


### PR DESCRIPTION
With the added "HTML" link style the selected text is copied with its original HTML format, plus a link appended at the end. The purpose is to preserve the text format rather than just copying the text string. 

Explanation of motivation: When copying text fragment for note taking, I want both the text and the link be placed in the note. The "rich" style actually provides this, but seems not perfect: 1) The original format is lost, but many apps can recognize the HTML during copy and display it pretty; 2) The link is applied to the whole text, which sometimes seems annoying especially when you want to select part of the copied text.

I noticed that the URL in the rich style has some encoding issue: the spaces are still space which should be %20. Didn't figure out a way to fix it. So in the HTML style, the link is added as a markdown style: `[🔗 ](url)`.
